### PR TITLE
Make sure refdata in TransferData() is sparse

### DIFF
--- a/R/integration.R
+++ b/R/integration.R
@@ -920,6 +920,9 @@ TransferData <- function(
     if (!slot %in% c("counts", "data")) {
       stop("Please specify slot as either 'counts' or 'data'.")
     }
+    if (inherits(x = refdata, what = "matrix")) {
+      refdata <- as(object = refdata, Class = "dgCMatrix")
+    }
     label.transfer <- FALSE
   } else {
     stop(paste0("Please provide either a vector (character or factor) for label transfer or a matrix",


### PR DESCRIPTION
To make sure the later [matrix multiplication](https://github.com/chenyenchung/seurat/blob/f195c4a75081713d057e648430a4d288ca752835/R/integration.R#L1033) gives a `dgCMatrix`, `refdata.anchors` must be a `dgCMatrix` but not a `matrix`. Otherwise, `new.data` will be a `dgematrix` and  will not be compatible with `[CreateAssayObject(counts = new.data)](https://github.com/chenyenchung/seurat/blob/f195c4a75081713d057e648430a4d288ca752835/R/integration.R#L1037)`.